### PR TITLE
Auto-source toolbelt configs

### DIFF
--- a/jobs/toolbelt/monit
+++ b/jobs/toolbelt/monit
@@ -1,4 +1,5 @@
-check file toolbelt
-  path /etc/envrc
-  start program "/bin/cp /var/vcap/jobs/toolbelt/envrc /etc/envrc"
+check process toolbelt
+  with pidfile /var/vcap/sys/run/toolbelt/toolbelt.pid
+  start program "/var/vcap/jobs/toolbelt/bin/monit_debugger toolbelt_ctl '/var/vcap/jobs/toolbelt/bin/ctl start'"
+  stop program "/var/vcap/jobs/toolbelt/bin/monit_debugger toolbelt_ctl '/var/vcap/jobs/toolbelt/bin/ctl stop'"
   group vcap

--- a/jobs/toolbelt/spec
+++ b/jobs/toolbelt/spec
@@ -2,6 +2,14 @@
 name: toolbelt
 packages: []
 templates:
+  bin/ctl: bin/ctl
+  bin/monit_debugger: bin/monit_debugger
+  data/properties.sh.erb: data/properties.sh
+  helpers/ctl_setup.sh: helpers/ctl_setup.sh
+  helpers/ctl_utils.sh: helpers/ctl_utils.sh
   envrc: envrc
 
-properties: {}
+properties:
+  toolbelt.auto:
+    description: Automatically configure the environment when you login.
+    default: true

--- a/jobs/toolbelt/templates/bin/ctl
+++ b/jobs/toolbelt/templates/bin/ctl
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+source /var/vcap/jobs/toolbelt/helpers/ctl_setup.sh 'toolbelt'
+export LANG=en_US.UTF-8
+
+setup_sleeper() {
+  FDIR=$(mktemp -d)
+  mkfifo $FDIR/fifo
+  exec 3<> $FDIR/fifo
+  trap "exec 2<&-; rm -r $FDIR" EXIT
+}
+
+checkenv() {
+  trap "exit 0" INT TERM QUIT
+  command=". ${JOB_DIR}/envrc"
+  <% if p('toolbelt.auto') %>
+  # toolbelt.auto is enabled; adding envrc to .profiles
+  for profile in /root/.profile /etc/skel/.profile; do
+    if ! grep -q "^${command}\$" ${profile} >/dev/null 2>&1; then
+      echo "${command}" >> ${profile}
+    fi
+  done
+
+  <% else %>
+  for profile in /root/.profile /etc/skel/.profile; do
+    # toolbelt.auto is disabled; stripping envrc from .profiles
+    if grep -q "^${command}\$" ${profile} >/dev/null 2>&1; then
+      sed -i -e "s@^${command}\$@@" ${profile}
+    fi
+  done
+  <% end %>
+
+  # sleep 60
+  read -t 60 -u 3 var || true
+}
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+    echo $$ > $PIDFILE
+    setup_sleeper
+    while true; do checkenv; done
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: master_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/toolbelt/templates/bin/monit_debugger
+++ b/jobs/toolbelt/templates/bin/monit_debugger
@@ -1,0 +1,13 @@
+#!/bin/sh
+# USAGE monit_debugger <label> command to run
+mkdir -p /var/vcap/sys/log/monit
+{
+  echo "MONIT-DEBUG date"
+  date
+  echo "MONIT-DEBUG env"
+  env
+  echo "MONIT-DEBUG $@"
+  $2 $3 $4 $5 $6 $7
+  R=$?
+  echo "MONIT-DEBUG exit code $R"
+} >/var/vcap/sys/log/monit/monit_debugger.$1.log 2>&1

--- a/jobs/toolbelt/templates/data/properties.sh.erb
+++ b/jobs/toolbelt/templates/data/properties.sh.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# job template binding variables
+
+# job name & index of this VM within cluster
+# e.g. JOB_NAME=redis, JOB_INDEX=0
+export NAME='<%= name %>'
+export JOB_INDEX=<%= index %>
+# full job name, like redis/0 or webapp/3
+export JOB_FULL="$NAME/$JOB_INDEX"

--- a/jobs/toolbelt/templates/envrc
+++ b/jobs/toolbelt/templates/envrc
@@ -16,3 +16,17 @@ for package in $(find /var/vcap/packages -type l -name 'toolbelt-*'); do
 		fi
 	done
 done
+
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+blue=$(tput setaf 4)
+cyan=$(tput setaf 6)
+rst=$(tput sgr0)
+PS1="==[]=[ ${cyan}<%= spec.deployment %>${rst} ${green}<%= spec.job.name %>/<%= spec.index %>${rst} ]=[]=="
+if [[ "${UID}" -eq 0 ]]; then
+	PS1="$PS1\n\\t ${red}\\u${rst} ${blue}\\w\\e \$${rst} "
+else
+	PS1="$PS1\n\\t ${blue}\\u \\w #${rst} "
+fi
+export PS1="\[${PS1}\]"

--- a/jobs/toolbelt/templates/helpers/ctl_setup.sh
+++ b/jobs/toolbelt/templates/helpers/ctl_setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Setup env vars and folders for the ctl script
+# This helps keep the ctl script as readable
+# as possible
+
+# Usage options:
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh JOB_NAME OUTPUT_LABEL
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar nginx
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+JOB_NAME=$1
+output_label=${2:-${JOB_NAME}}
+
+export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+chmod 755 $JOB_DIR # to access file via symlink
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
+
+source $JOB_DIR/helpers/ctl_utils.sh
+redirect_output ${output_label}
+
+export HOME=${HOME:-/home/vcap}
+
+# Add all packages' /bin & /sbin into $PATH
+for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+do
+  export PATH=${package_bin_dir}:$PATH
+done
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_bin_dir in $(ls -d /var/vcap/packages/*/lib)
+do
+  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+done
+
+# Setup log, run and tmp folders
+
+export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
+export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
+export STORE_DIR=/var/vcap/store/$JOB_NAME
+for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR
+do
+  mkdir -p ${dir}
+  chown vcap:vcap ${dir}
+  chmod 775 ${dir}
+done
+export TMPDIR=$TMP_DIR
+
+export C_INCLUDE_PATH=/var/vcap/packages/mysqlclient/include/mysql:/var/vcap/packages/sqlite/include:/var/vcap/packages/libpq/include
+export LIBRARY_PATH=/var/vcap/packages/mysqlclient/lib/mysql:/var/vcap/packages/sqlite/lib:/var/vcap/packages/libpq/lib
+
+# consistent place for vendoring python libraries within package
+if [[ -d ${WEBAPP_DIR:-/xxxx} ]]
+then
+  export PYTHONPATH=$WEBAPP_DIR/vendor/lib/python
+fi
+
+if [[ -d /var/vcap/packages/java7 ]]
+then
+  export JAVA_HOME="/var/vcap/packages/java7"
+fi
+
+# setup CLASSPATH for all jars/ folders within packages
+export CLASSPATH=${CLASSPATH:-''} # default to empty
+for java_jar in $(ls -d /var/vcap/packages/*/*/*.jar)
+do
+  export CLASSPATH=${java_jar}:$CLASSPATH
+done
+
+PIDFILE=$RUN_DIR/$output_label.pid
+
+echo '$PATH' $PATH

--- a/jobs/toolbelt/templates/helpers/ctl_utils.sh
+++ b/jobs/toolbelt/templates/helpers/ctl_utils.sh
@@ -1,0 +1,155 @@
+# Helper functions used by ctl scripts
+
+# links a job file (probably a config file) into a package
+# Example usage:
+# link_job_file_to_package config/redis.yml [config/redis.yml]
+# link_job_file_to_package config/wp-config.php wp-config.php
+link_job_file_to_package() {
+  source_job_file=$1
+  target_package_file=${2:-$source_job_file}
+  full_package_file=$WEBAPP_DIR/${target_package_file}
+
+  link_job_file ${source_job_file} ${full_package_file}
+}
+
+# links a job file (probably a config file) somewhere
+# Example usage:
+# link_job_file config/bashrc /home/vcap/.bashrc
+link_job_file() {
+  source_job_file=$1
+  target_file=$2
+  full_job_file=$JOB_DIR/${source_job_file}
+
+  echo link_job_file ${full_job_file} ${target_file}
+  if [[ ! -f ${full_job_file} ]]
+  then
+    echo "file to link ${full_job_file} does not exist"
+  else
+    # Create/recreate the symlink to current job file
+    # If another process is using the file, it won't be
+    # deleted, so don't attempt to create the symlink
+    mkdir -p $(dirname ${target_file})
+    ln -nfs ${full_job_file} ${target_file}
+  fi
+}
+
+# If loaded within monit ctl scripts then pipe output
+# If loaded from 'source ../utils.sh' then normal STDOUT
+redirect_output() {
+  SCRIPT=$1
+  mkdir -p /var/vcap/sys/log/monit
+  exec 1>> /var/vcap/sys/log/monit/$SCRIPT.log 2>&1
+}
+
+pid_guard() {
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pid() {
+  pid=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  echo wait_pid $pid $try_kill $timeout $force $countdown
+  if [ -e /proc/$pid ]; then
+    if [ "$try_kill" = "1" ]; then
+      echo "Killing $pidfile: $pid "
+      kill $pid
+    fi
+    while [ -e /proc/$pid ]; do
+      sleep 0.1
+      [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+      if [ $timeout -gt 0 ]; then
+        if [ $countdown -eq 0 ]; then
+          if [ "$force" = "1" ]; then
+            echo -ne "\nKill timed out, using kill -9 on $pid... "
+            kill -9 $pid
+            sleep 0.5
+          fi
+          break
+        else
+          countdown=$(( $countdown - 1 ))
+        fi
+      fi
+    done
+    if [ -e /proc/$pid ]; then
+      echo "Timed Out"
+    else
+      echo "Stopped"
+    fi
+  else
+    echo "Process $pid is not running"
+    echo "Attempting to kill pid anyway..."
+    kill $pid
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    wait_pid $pid $try_kill $timeout $force
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+  if [[ -f ${pidfile} ]]
+  then
+    wait_pidfile $pidfile 1 $timeout $force
+  else
+    # TODO assume $1 is something to grep from 'ps ax'
+    pid="$(ps auwwx | grep "$1" | awk '{print $2}')"
+    wait_pid $pid 1 $timeout $force
+  fi
+}
+
+check_nfs_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -21,4 +21,6 @@ jobs:
 
 networks: (( param "please set networks" ))
 
-properties: {}
+properties:
+  toolbelt:
+    auto: true


### PR DESCRIPTION
If `toolbelt.auto` is set to true, /etc/skel/.profile and /root/.profile
will be updated to source the /var/vcap/jobs/toolbelt/envrc
automatically.  The former allows new `bosh ssh` sessions to function
and the latter means that you don't lose stuff when you `sudo -i`

This commit also introduces a new colorized prompt for toolbelt that
provides useful information about what deployment / job / index you are
currently logged into, and visually differentiates root from non-root.
