### PR TITLE
add cfdot to toolbelt-boshrelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, add the desired `toolbelt-*` templates to your releases:
     releases:
       - name: toolbelt
         version: latest
-        
+
 Or if you're looking to use `toolbelt` as a BOSH `add-on` via `runtime-config`:
 
     addons:
@@ -77,6 +77,7 @@ Tools On The Belt
 The following `toolbelt-*` jobs exist:
 
 - `toolbelt-cf` - The Cloud Foundry CLI, [cf][cf]
+- `toolbelt-cfdot` - The Cloud Foundry Diego Operator Kit, [cfdot][cfdot]
 - `toolbelt-esuf` - The ElasticSearch Unassigned Fixer,
   [esuf][esuf], for finding and fixigin UNASSIGNED shards on an
   ElasticSearch cluster (i.e. Logsearch)
@@ -122,6 +123,7 @@ Then, you can `bosh ssh` and see what it is like using Toolbelt!
 
 
 [cf]:          https://github.com/cloudfoundry/cli
+[cfdot]:       https://github.com/cloudfoundry/cfdot
 [esuf]:        https://github.com/starkandwayne/esuf
 [gaol]:        https://github.com/contraband/gaol
 [gotcha]:      https://github.com/jhunt/gotcha

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -5,3 +5,10 @@
   a loopback TCP port, or a UNIX domain socket, via the
   `stats` configuration directive.  It shows useful things like
   backend states, pool load, and more!
+- `cfdot` is the new Diego Operator Toolkit, a cli that helps
+  you understand what's going on in your diego deployment and
+  make changes directly against a running system. For example,
+  cfdot give you the ability to directly manage tasks, LRPs,
+  locks, etc, all without the need for a fully functional cf
+  cloud controller stack.
+

--- a/jobs/toolbelt-cfdot/spec
+++ b/jobs/toolbelt-cfdot/spec
@@ -1,0 +1,8 @@
+---
+name: toolbelt-cfdot
+packages:
+  - toolbelt-cfdot
+templates:
+  bin/run: bin/run
+
+properties: {}

--- a/jobs/toolbelt-cfdot/templates/bin/run
+++ b/jobs/toolbelt-cfdot/templates/bin/run
@@ -1,0 +1,21 @@
+#!/bin/sh
+test -n "$ITS_OKAY_TOOLBELT_IS_RUNNING_ERRANDS" && exit 0
+cat <<EOF
+
+   **** WARNING ****
+
+   You appear to have loaded the [toolbelt] release on an errand VM.
+   This is totally okay, and normally would not cause any problems,
+   however the toolbelt* templates have superseded the actual errand
+   templates.
+
+   This isn't great.
+
+   You probably wanted to run your _actual_ errands, not the toolbelt
+   errand script.  If so, you'll need to move the toolbelt-y parts of
+   the errand jobs \`templates:' section to the bottom.
+
+   **** WARNING ****
+
+EOF
+exit 42

--- a/jobs/toolbelt-everything/spec
+++ b/jobs/toolbelt-everything/spec
@@ -2,6 +2,7 @@
 name: toolbelt-everything
 packages:
   - toolbelt-cf
+  - toolbelt-cfdot
   - toolbelt-esuf
   - toolbelt-gaol
   - toolbelt-gotcha

--- a/jobs/toolbelt-quick/spec
+++ b/jobs/toolbelt-quick/spec
@@ -2,6 +2,7 @@
 name: toolbelt-quick
 packages:
   - toolbelt-cf
+  - toolbelt-cfdot
   - toolbelt-esuf
   - toolbelt-hatop
   - toolbelt-gaol

--- a/packages/toolbelt-cfdot/packaging
+++ b/packages/toolbelt-cfdot/packaging
@@ -1,0 +1,12 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Detect # of CPUs so make jobs can be parallelized
+CPUS=$(grep -c ^processor /proc/cpuinfo)
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+export HOME=/var/vcap
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+cp cfdot/cfdot-linux64 ${BOSH_INSTALL_TARGET}/bin/cfdot
+chmod 755 ${BOSH_INSTALL_TARGET}/bin/cfdot

--- a/packages/toolbelt-cfdot/spec
+++ b/packages/toolbelt-cfdot/spec
@@ -1,0 +1,6 @@
+---
+name: toolbelt-cfdot
+dependencies: []
+files:
+  - cfdot/cfdot-linux64
+


### PR DESCRIPTION
cfdot could be a nice addition to this release. It seems like the pattern in here is to build a linux binary and then install it as a package during deployment time, so for this to work you also need to build the cfdot binary and place it in `blobs/cfdot`. Here are steps to build cfdot:

```
# get diego deps, easiest way to get those is from diego-release
git clone https://github.com/cloudfoundry/diego-release.git
cd diego-release
git submodule init
git submodule update # wait for all the diego deps to download
GOPATH=/path/to/diego-release go get code.cloudfoundry.org/cfdot
cd /path/to/diego-release/src/code.cloudfoundry.org/cfdot
GOPATH=/path/to/diego-release GOOS=linux go build .
```

then:
 * copy `$GOPATH/bin/cfdot` to `/path/to/toolbelt-boshrelease/blobs/cfdot/cfdot-linux64`
 * `bosh sync blobs`
 * etc
