### PR TITLE
2026-Q2: tool version bumps (boss, cf, nats, nmap, psql, spruce, tree)

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,6 @@
 boss/boss-linux-amd64:
-  size: 7279015
-  object_id: 3277b45a-318b-4361-79eb-14b6719387ae
-  sha: sha256:752b35912e0cb5ba2387c0c7a50a30c3c2380c02cd6cbd1bd34e56476384f22b
+  size: 9653586
+  sha: sha256:d282dd2bfc62b550398082df84c671c802dfa7610d05cb2a32a93069bb540fa8
 cf-cli/cf7-cli_7.7.12_linux_x86-64.tgz:
   size: 7624800
   object_id: 0bf8fb02-b7c4-424b-4a8c-94f7c8008371

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -85,14 +85,12 @@ openbao/bao_2.5.4_Linux_x86_64.tar.gz:
   size: 72596286
   object_id: 181dbbcd-989c-41bf-4ff3-23a988927559
   sha: sha256:7690853adccaf9bc413768e6bfed4d0ac5222b67f808ba71af0930189f22f94f
-postgresql/postgresql-16.13.tar.gz:
-  size: 32997122
-  object_id: 4071ac2b-28b5-4ec4-7ce6-6850285bdf60
-  sha: sha256:9b767d0dfd156424b0b8f02b65eebb4b6958ef6413ebf7c8349e28b0b91e6b09
-postgresql/postgresql-18.3.tar.gz:
-  size: 29416481
-  object_id: ec9997bc-9eca-4da1-7291-b598091b15c3
-  sha: sha256:9e054ffd6e013da2c2c9a1bfd6e062c98875d340df080516551c96b9b0926a59
+postgresql/postgresql-16.14.tar.gz:
+  size: 33046588
+  sha: sha256:ca18d43510bbb09a271383e1aa705b05b76bc8e9400f9857178ba8ec54cf461a
+postgresql/postgresql-18.4.tar.gz:
+  size: 29477735
+  sha: sha256:450aa8f2da06c46f8221916e82ae06b04fb1040f8f00643dbf8b7d663caac0b9
 python/Python-3.10.13.tgz:
   size: 26111363
   object_id: 24146d09-0663-49ec-601f-c006a1ca7d05

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -78,10 +78,9 @@ nload/nload-0.7.4.tar.gz:
   size: 151005
   object_id: fe9d2165-bca8-48ff-6f88-79b628070039
   sha: bb0a168c93c588ad4fd5e3a653b3620b79ada1e8
-nmap/nmap-7.98.tar.bz2:
-  size: 12273108
-  object_id: 31803e8e-f91e-4b2e-7ff8-7e4574417fcf
-  sha: sha256:ce847313eaae9e5c9f21708e42d2ab7b56c7e0eb8803729a3092f58886d897e6
+nmap/nmap-7.99.tar.bz2:
+  size: 13036588
+  sha: sha256:df512492ffd108e53a27a06f26d8635bbe89e0e569455dc8ffef058c035d51b2
 openbao/bao_2.5.4_Linux_x86_64.tar.gz:
   size: 72596286
   object_id: 181dbbcd-989c-41bf-4ff3-23a988927559

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,11 +1,14 @@
 boss/boss-linux-amd64:
   size: 9653586
+  object_id: 6fbd476c-ee68-4b0e-5cc7-dbe64f9cef73
   sha: sha256:d282dd2bfc62b550398082df84c671c802dfa7610d05cb2a32a93069bb540fa8
 cf-cli/cf7-cli_7.8.0_linux_x86-64.tgz:
   size: 7815617
+  object_id: 6bc187e4-b507-4823-5c02-437ac519f29a
   sha: sha256:a663907f7a7ad193b6e3d3e7af7f916925f9e6e21a6a500e4711a46413aa1e74
 cf-cli/cf8-cli_8.18.3_linux_x86-64.tgz:
   size: 9765051
+  object_id: 15e2acd1-da01-4ff9-4c7c-98a7a2dc90ea
   sha: sha256:8942e2c3c98e83c7e14edbce939876bba7ff12a26f0f722c5aa5b079d357d50b
 cfdot/cfdot-linux64:
   size: 24614808
@@ -25,6 +28,7 @@ mysql/mariadb-11.4.10.tar.gz:
   sha: sha256:14783ddc5edd966ff05aa0efd5ed6d3d369ed5b9e4080a448f00f87a9f0a4a6b
 nats/nats-0.4.0-linux-amd64.zip:
   size: 9609864
+  object_id: 07349793-96cb-46fd-7910-62d5960e4ab4
   sha: sha256:8dbd437c826b953dbd7432cf890ef22ba3c33dccc3dce5e71b3e8d055427849c
 ncurses/ncurses-6.3.tar.gz:
   size: 3583550
@@ -80,6 +84,7 @@ nload/nload-0.7.4.tar.gz:
   sha: bb0a168c93c588ad4fd5e3a653b3620b79ada1e8
 nmap/nmap-7.99.tar.bz2:
   size: 13036588
+  object_id: 166b9e1b-d557-4485-5a47-c604bce92ba8
   sha: sha256:df512492ffd108e53a27a06f26d8635bbe89e0e569455dc8ffef058c035d51b2
 openbao/bao_2.5.4_Linux_x86_64.tar.gz:
   size: 72596286
@@ -87,9 +92,11 @@ openbao/bao_2.5.4_Linux_x86_64.tar.gz:
   sha: sha256:7690853adccaf9bc413768e6bfed4d0ac5222b67f808ba71af0930189f22f94f
 postgresql/postgresql-16.14.tar.gz:
   size: 33046588
+  object_id: 44ab9f49-e020-4b33-647a-b9ddb0707fcf
   sha: sha256:ca18d43510bbb09a271383e1aa705b05b76bc8e9400f9857178ba8ec54cf461a
 postgresql/postgresql-18.4.tar.gz:
   size: 29477735
+  object_id: 03df9da8-ca12-48c5-7714-efbaa0664d38
   sha: sha256:450aa8f2da06c46f8221916e82ae06b04fb1040f8f00643dbf8b7d663caac0b9
 python/Python-3.10.13.tgz:
   size: 26111363
@@ -113,6 +120,7 @@ screen/screen-5.0.1.tar.gz:
   sha: sha256:2dae36f4db379ffcd14b691596ba6ec18ac3a9e22bc47ac239789ab58409869d
 spruce/spruce-linux-amd64:
   size: 30125863
+  object_id: a02e83a7-6992-4f1d-6589-9bcbe53d3849
   sha: sha256:a7b468898530430dd58c9c8bcb2f66c4f1a1d30f8560aadc5b5eeb5fe31c9a45
 tcptrace/tcptrace:
   size: 2983
@@ -120,6 +128,7 @@ tcptrace/tcptrace:
   sha: 1209e7f64081c4edcf067927e09587aa351bef4d
 tree/tree-2.3.2.tgz:
   size: 70885
+  object_id: 6224ecc8-6303-4368-5701-1c3037e203f6
   sha: sha256:6b941dd6cbecfb4d3250700e4d08d8e0c251488981dd4868b90d744234300e21
 tshark/c-ares-1.34.6.tar.gz:
   size: 1017864

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,6 @@ cf-cli/cf8-cli_8.18.3_linux_x86-64.tgz:
   size: 9765051
   object_id: 15e2acd1-da01-4ff9-4c7c-98a7a2dc90ea
   sha: sha256:8942e2c3c98e83c7e14edbce939876bba7ff12a26f0f722c5aa5b079d357d50b
-cfdot/cfdot-linux64:
-  size: 24614808
-  object_id: b673e243-7c22-4fd3-5ec2-945d8557c4f1
-  sha: sha256:3c4bfbab50aba7e21aa4d0617990f6f59c1ad391b092edf65f1cd5eae95741b7
 gaol/gaol-linux64:
   size: 8700442
   object_id: 6176383a-4259-4974-7ab8-7ca840f104c3
@@ -30,10 +26,6 @@ nats/nats-0.4.0-linux-amd64.zip:
   size: 9609864
   object_id: 07349793-96cb-46fd-7910-62d5960e4ab4
   sha: sha256:8dbd437c826b953dbd7432cf890ef22ba3c33dccc3dce5e71b3e8d055427849c
-ncurses/ncurses-6.3.tar.gz:
-  size: 3583550
-  object_id: 66dc7a7e-b729-4c87-4ae0-e32c10529fb1
-  sha: sha256:97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059
 netsniff-ng/libcli-1.10.7.tar.gz:
   size: 55713
   object_id: 3385619c-a44f-4f1e-725d-9157a9718192
@@ -98,10 +90,6 @@ postgresql/postgresql-18.4.tar.gz:
   size: 29477735
   object_id: 03df9da8-ca12-48c5-7714-efbaa0664d38
   sha: sha256:450aa8f2da06c46f8221916e82ae06b04fb1040f8f00643dbf8b7d663caac0b9
-python/Python-3.10.13.tgz:
-  size: 26111363
-  object_id: 24146d09-0663-49ec-601f-c006a1ca7d05
-  sha: sha256:698ec55234c1363bd813b460ed53b0f108877c7a133d48bde9a50a1eb57b7e65
 python/Python-3.14.2.tgz:
   size: 30601597
   object_id: ae7aff70-bfec-4130-552d-8f305502fc64

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -23,10 +23,9 @@ mysql/mariadb-11.4.10.tar.gz:
   size: 120394058
   object_id: c63754b8-e3af-45c6-632d-3621c466586d
   sha: sha256:14783ddc5edd966ff05aa0efd5ed6d3d369ed5b9e4080a448f00f87a9f0a4a6b
-nats/nats-0.3.1-linux-amd64.zip:
-  size: 11853415
-  object_id: 7f827aa3-643f-40bf-5604-1831a08d0d7f
-  sha: sha256:f48374be6fc903b954b90b729321772bdd5bc745234edf3d31cd17ab79e85629
+nats/nats-0.4.0-linux-amd64.zip:
+  size: 9609864
+  sha: sha256:8dbd437c826b953dbd7432cf890ef22ba3c33dccc3dce5e71b3e8d055427849c
 ncurses/ncurses-6.3.tar.gz:
   size: 3583550
   object_id: 66dc7a7e-b729-4c87-4ae0-e32c10529fb1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,14 +1,12 @@
 boss/boss-linux-amd64:
   size: 9653586
   sha: sha256:d282dd2bfc62b550398082df84c671c802dfa7610d05cb2a32a93069bb540fa8
-cf-cli/cf7-cli_7.7.12_linux_x86-64.tgz:
-  size: 7624800
-  object_id: 0bf8fb02-b7c4-424b-4a8c-94f7c8008371
-  sha: sha256:c507d0191304d29fdda04ad35147d47a7ca0bd801fb9a840c15ddb6eac023e06
-cf-cli/cf8-cli_8.8.0_linux_x86-64.tgz:
-  size: 9199900
-  object_id: 7829bd6a-cdec-4b4d-6323-453d58503319
-  sha: sha256:fa33d65327e72bc90d9d6f3751aa0a8db3f8168f011740649fa9519c8f0111bb
+cf-cli/cf7-cli_7.8.0_linux_x86-64.tgz:
+  size: 7815617
+  sha: sha256:a663907f7a7ad193b6e3d3e7af7f916925f9e6e21a6a500e4711a46413aa1e74
+cf-cli/cf8-cli_8.18.3_linux_x86-64.tgz:
+  size: 9765051
+  sha: sha256:8942e2c3c98e83c7e14edbce939876bba7ff12a26f0f722c5aa5b079d357d50b
 cfdot/cfdot-linux64:
   size: 24614808
   object_id: b673e243-7c22-4fd3-5ec2-945d8557c4f1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -118,10 +118,9 @@ tcptrace/tcptrace:
   size: 2983
   object_id: 0975577c-b183-4e7f-bb13-8db0f1e49361
   sha: 1209e7f64081c4edcf067927e09587aa351bef4d
-tree/tree-2.3.1.tgz:
-  size: 70339
-  object_id: c11c62b4-a123-4f3f-4cbc-b6e1ac2e9b8a
-  sha: sha256:47ca786ed4ea4aa277cabd42b1a54635aca41b29e425e9229bd1317831f25665
+tree/tree-2.3.2.tgz:
+  size: 70885
+  sha: sha256:6b941dd6cbecfb4d3250700e4d08d8e0c251488981dd4868b90d744234300e21
 tshark/c-ares-1.34.6.tar.gz:
   size: 1017864
   object_id: 063b5d18-f495-42c4-49d9-992cb40b9036

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -113,7 +113,6 @@ screen/screen-5.0.1.tar.gz:
   sha: sha256:2dae36f4db379ffcd14b691596ba6ec18ac3a9e22bc47ac239789ab58409869d
 spruce/spruce-linux-amd64:
   size: 30125863
-  object_id: d7bef635-b668-443e-5e79-cbe41292e286
   sha: sha256:a7b468898530430dd58c9c8bcb2f66c4f1a1d30f8560aadc5b5eeb5fe31c9a45
 tcptrace/tcptrace:
   size: 2983

--- a/packages/toolbelt-boss/packaging
+++ b/packages/toolbelt-boss/packaging
@@ -1,8 +1,8 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-# Downloaded from: https://github.com/blacksmith-community/boss/releases/tag/v0.0.6
-# boss version:	v0.0.6
+# Downloaded from: https://github.com/blacksmith-community/boss/releases/tag/v1.0.0
+# boss version:	v1.0.0
 
 
 export HOME=/var/vcap

--- a/packages/toolbelt-cf/packaging
+++ b/packages/toolbelt-cf/packaging
@@ -3,8 +3,8 @@ set -u # report the usage of uninitialized variables
 
 # link: https://github.com/cloudfoundry/cli/releases
 # toolbelt-cf
-# 	- cf7 version:	7.7.12
-# 	- cf8 version:	8.8.0
+# 	- cf7 version:	7.8.0
+# 	- cf8 version:	8.18.3
 
 
 # Detect # of CPUs so make jobs can be parallelized
@@ -17,12 +17,12 @@ export HOME=/var/vcap
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
 (
-tar -xzf cf-cli/cf7-cli_7.7.12_linux_x86-64.tgz cf7 &&
+tar -xzf cf-cli/cf7-cli_7.8.0_linux_x86-64.tgz cf7 &&
 cp cf7 ${BOSH_INSTALL_TARGET}/bin &&
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/cf7) || exit 1
 
 (
-tar -xzf cf-cli/cf8-cli_8.8.0_linux_x86-64.tgz cf8 &&
+tar -xzf cf-cli/cf8-cli_8.18.3_linux_x86-64.tgz cf8 &&
 cp cf8 ${BOSH_INSTALL_TARGET}/bin &&
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/cf8) || exit 1
 

--- a/packages/toolbelt-cf/spec
+++ b/packages/toolbelt-cf/spec
@@ -2,5 +2,5 @@
 name: toolbelt-cf
 dependencies: []
 files:
-  - cf-cli/cf7-cli_7.7.12_linux_x86-64.tgz
-  - cf-cli/cf8-cli_8.8.0_linux_x86-64.tgz
+  - cf-cli/cf7-cli_7.8.0_linux_x86-64.tgz
+  - cf-cli/cf8-cli_8.18.3_linux_x86-64.tgz

--- a/packages/toolbelt-nats/packaging
+++ b/packages/toolbelt-nats/packaging
@@ -13,7 +13,7 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 export HOME=/var/vcap
 
 cd nats
-unzip nats-0.3.1-linux-amd64.zip
+unzip nats-0.4.0-linux-amd64.zip
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-cp nats-0.3.1-linux-amd64/nats ${BOSH_INSTALL_TARGET}/bin/nats
+cp nats-0.4.0-linux-amd64/nats ${BOSH_INSTALL_TARGET}/bin/nats
 chmod 755 ${BOSH_INSTALL_TARGET}/bin/nats

--- a/packages/toolbelt-nats/spec
+++ b/packages/toolbelt-nats/spec
@@ -2,4 +2,4 @@
 name: toolbelt-nats
 dependencies: []
 files:
-  - nats/nats-0.3.1-linux-amd64.zip
+  - nats/nats-0.4.0-linux-amd64.zip

--- a/packages/toolbelt-nmap/packaging
+++ b/packages/toolbelt-nmap/packaging
@@ -2,9 +2,9 @@
 set -eu
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
-# retrieved from https://nmap.org/dist/nmap-7.98.tar.bz2
+# retrieved from https://nmap.org/dist/nmap-7.99.tar.bz2
 
-VERSION=7.98
+VERSION=7.99
 tar -xjvf nmap/nmap-${VERSION}.tar.bz2
 cd nmap-${VERSION}
 ./configure

--- a/packages/toolbelt-nmap/spec
+++ b/packages/toolbelt-nmap/spec
@@ -2,4 +2,4 @@
 name: toolbelt-nmap
 dependencies: []
 files:
-  - nmap/nmap-7.98.tar.bz2
+  - nmap/nmap-7.99.tar.bz2

--- a/packages/toolbelt-psql/packaging
+++ b/packages/toolbelt-psql/packaging
@@ -8,14 +8,14 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 export HOME=/var/vcap
 
-# download from https://ftp.postgresql.org/pub/source/v16.13/postgresql-16.13.tar.gz
-# download from https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.gz
+# download from https://ftp.postgresql.org/pub/source/v16.14/postgresql-16.14.tar.gz
+# download from https://ftp.postgresql.org/pub/source/v18.4/postgresql-18.4.tar.gz
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 mkdir -p ${BOSH_INSTALL_TARGET}/lib
 
 # --- Build psql 16 ---
-VERSION_16=16.13
+VERSION_16=16.14
 TMPDIR_16=$(mktemp -d)
 
 tar -zxf "postgresql/postgresql-${VERSION_16}.tar.gz"
@@ -37,7 +37,7 @@ cp -a "${TMPDIR_16}"/lib/*.so* "${BOSH_INSTALL_TARGET}/lib/" 2>/dev/null || true
 echo "Installed psql16 (PostgreSQL ${VERSION_16})"
 
 # --- Build psql 18 ---
-VERSION_18=18.3
+VERSION_18=18.4
 TMPDIR_18=$(mktemp -d)
 
 tar -zxf "postgresql/postgresql-${VERSION_18}.tar.gz"

--- a/packages/toolbelt-psql/spec
+++ b/packages/toolbelt-psql/spec
@@ -2,5 +2,5 @@
 name: toolbelt-psql
 dependencies: []
 files:
-  - postgresql/postgresql-16.13.tar.gz
-  - postgresql/postgresql-18.3.tar.gz
+  - postgresql/postgresql-16.14.tar.gz
+  - postgresql/postgresql-18.4.tar.gz

--- a/packages/toolbelt-spruce/packaging
+++ b/packages/toolbelt-spruce/packaging
@@ -2,6 +2,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # link: https://github.com/geofffranks/spruce/releases
+# spruce version:	v1.35.5
 
 
 # Detect # of CPUs so make jobs can be parallelized

--- a/packages/toolbelt-spruce/spec
+++ b/packages/toolbelt-spruce/spec
@@ -2,5 +2,5 @@
 name: toolbelt-spruce
 dependencies: []
 files:
-    # https://github.com/geofffranks/spruce/releases/download/v1.31.1/spruce-linux-amd64
+    # https://github.com/geofffranks/spruce/releases/download/v1.35.5/spruce-linux-amd64
   - spruce/spruce-linux-amd64

--- a/packages/toolbelt-tree/packaging
+++ b/packages/toolbelt-tree/packaging
@@ -2,7 +2,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # link: https://github.com/Old-Man-Programmer/tree
-# tree version: 2.3.1
+# tree version: 2.3.2
 # https://oldmanprogrammer.net/source.php?dir=projects/tree
 
 
@@ -14,8 +14,8 @@ CPUS=$(grep -c ^processor /proc/cpuinfo)
 export HOME=/var/vcap
 
 # Running in a subshell since I might be messing with the exportability of BOSH_INSTALL_TARGET
-tar -xzvf tree/tree-2.3.1.tgz
-( cd tree-2.3.1
+tar -xzvf tree/tree-2.3.2.tgz
+( cd tree-2.3.2
   export BOSH_INSTALL_TARGET
   make -j${CPUS}
   make PREFIX="${BOSH_INSTALL_TARGET}" install ) || exit 1

--- a/packages/toolbelt-tree/spec
+++ b/packages/toolbelt-tree/spec
@@ -2,4 +2,4 @@
 name: toolbelt-tree
 dependencies: []
 files:
-  - tree/tree-2.3.1.tgz
+  - tree/tree-2.3.2.tgz


### PR DESCRIPTION
## Summary

First of three PRs for the 2026-Q2 cycle. Patch/minor bumps for binary and source-build tools — no schema changes, no tool additions/removals.

### Version bumps

| Tool | From | To | Type | Note |
|---|---|---|---|---|
| boss | v0.0.6 | **v1.0.0** | binary | Major bump from upstream; same asset name (`boss-linux-amd64`) |
| cf cli (cf7) | 7.7.12 | **7.8.0** | binary | cf7 line retained intentionally alongside cf8 |
| cf cli (cf8) | 8.8.0 | **8.18.3** | binary | 10 minors of upstream cf8 patches |
| nats (natscli) | 0.3.1 | **v0.4.0** | binary | |
| nmap | 7.98 | **7.99** | source | |
| psql 16 | 16.13 | **16.14** | source | Dual-line package — both 16.x and 18.x updated in the same commit |
| psql 18 | 18.3 | **18.4** | source | |
| spruce | v1.31.1 | **v1.35.5** | binary | 4 minors of upstream spruce work |
| tree | 2.3.1 | **2.3.2** | source | |

### Cleanup

- Removed three orphan blob registry entries that became unreferenced earlier in the 2025-Q4 cycle but were never cleaned up:
  - `cfdot/cfdot-linux64` — cfdot was dropped in 2025-Q4 (commit 5e0d71a)
  - `ncurses/ncurses-6.3.tar.gz` — superseded by `netsniff-ng/ncurses-6.5.tar.gz` (bundled inside netsniff-ng package)
  - `python/Python-3.10.13.tgz` — superseded by `tshark/Python-3.14.2.tgz` (bundled inside tshark package)

### Not in this PR

- **mariadb** — own PR (planned 11.4.10 → 11.8.7b LTS jump)
- **wireshark/tshark** — own PR (planned 4.4.2 → 4.6.6)
- **netsniff-ng** — own PR (Jammy compile fix + 0.6.8 → 0.6.9; currently disabled in `toolbelt-everything`)

## Test plan

- [x] `bosh upload-blobs` succeeds for the 9 new blobs
- [x] `bosh create-release --force --timestamp-version` builds dev `4.0.0+dev.1779782746`
- [x] Uploaded to internal `ocfp-aws-lab-ocf-us-east-1` director
- [x] Deployed against `emptyvm` on the lab (toolbelt-quick + toolbelt-valkey + boss + nmap + psql jobs)
- [x] All bumped packages compile cleanly on Ubuntu Jammy:
  - boss (1:16), cf (1:33), nats (1:18), nmap (4:24), psql 16+18 (9:55), spruce (1:55), tree (1:39) — plus quick-deps redis (4:10), valkey (4:58), etc.
