### PR TITLE
2026-Q2: mariadb 11.4.10 → 11.8.7 LTS jump

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,10 +18,9 @@ jq/jq-1.8.1-linux-amd64:
   size: 2255816
   object_id: acf22495-3aac-41c4-6869-33be56c388e0
   sha: sha256:020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d
-mysql/mariadb-11.4.10.tar.gz:
-  size: 120394058
-  object_id: c63754b8-e3af-45c6-632d-3621c466586d
-  sha: sha256:14783ddc5edd966ff05aa0efd5ed6d3d369ed5b9e4080a448f00f87a9f0a4a6b
+mysql/mariadb-11.8.7.tar.gz:
+  size: 119377507
+  sha: sha256:1a23a21549ce6e4803f0f149159e5c76b925f6fa4c955a4064f9c472b4b79a05
 nats/nats-0.4.0-linux-amd64.zip:
   size: 9609864
   object_id: 07349793-96cb-46fd-7910-62d5960e4ab4

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,6 +20,7 @@ jq/jq-1.8.1-linux-amd64:
   sha: sha256:020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d
 mysql/mariadb-11.8.7.tar.gz:
   size: 119377507
+  object_id: 2ef0552a-88e8-425a-6bf6-1a913c655015
   sha: sha256:1a23a21549ce6e4803f0f149159e5c76b925f6fa4c955a4064f9c472b4b79a05
 nats/nats-0.4.0-linux-amd64.zip:
   size: 9609864

--- a/packages/toolbelt-mysql-client/packaging
+++ b/packages/toolbelt-mysql-client/packaging
@@ -3,9 +3,9 @@ set -u # report the usage of uninitialized variables
 
 # link: https://mariadb.com/kb/en/release-notes/
 # link: https://dlm.mariadb.com/browse/mariadb\_server/
-# mysql version:	Ver 15.1 Distrib 11.4.10-MariaDB
-# https://mariadb.com/docs/platform/post-download/mariadb-server-11.4.10
-# https://mariadb.org/download/?t=mariadb&o=true&p=mariadb&r=11.4.10&os=source&mirror=archive
+# mysql version:	Ver 15.1 Distrib 11.8.7-MariaDB
+# https://mariadb.com/docs/platform/post-download/mariadb-server-11.8.7
+# download from https://archive.mariadb.org/mariadb-11.8.7/source/mariadb-11.8.7.tar.gz
 
 # Detect # of CPUs so make jobs can be parallelized
 CPUS=$(grep -c ^processor /proc/cpuinfo)
@@ -20,8 +20,8 @@ export LDFLAGS=-L${LD_LIBRARY_PATH}
 export CPPFLAGS=-I${INCLUDE_PATH}
 export PATH=${PATH}:${BOSH_INSTALL_TARGET}/bin:${BOSH_INSTALL_TARGET}/sbin
 
-tar -xzf mysql/mariadb-11.4.10.tar.gz
-(cd mariadb-11.4.10/
+tar -xzf mysql/mariadb-11.8.7.tar.gz
+(cd mariadb-11.8.7/
   cmake -DCMAKE_INSTALL_PREFIX:PATH=${BOSH_INSTALL_TARGET} -DWITHOUT_SERVER:BOOL=ON && \
   make && \
   make install) || exit 1

--- a/packages/toolbelt-mysql-client/spec
+++ b/packages/toolbelt-mysql-client/spec
@@ -2,4 +2,4 @@
 name: toolbelt-mysql-client
 dependencies: []
 files:
-  - mysql/mariadb-11.4.10.tar.gz
+  - mysql/mariadb-11.8.7.tar.gz


### PR DESCRIPTION
## Summary

Second of three PRs for the 2026-Q2 cycle. Jumps the mariadb client from the 11.4.x LTS line to the **11.8.x LTS** line.

### Version bump

| Tool | From | To | Type | Note |
|---|---|---|---|---|
| mariadb (client) | 11.4.10 | **11.8.7** | source | LTS line jump, not a patch — wider behavior surface than typical bumps |

Package is `toolbelt-mysql-client` (client-only, `-DWITHOUT_SERVER:BOOL=ON`).

### Not in this PR

- **wireshark/tshark** — own PR (planned 4.4.2 → 4.6.6)
- **netsniff-ng** — own PR (Jammy compile fix + 0.6.8 → 0.6.9; currently disabled in `toolbelt-everything`)

## Test plan

- [x] Downloaded `mariadb-11.8.7.tar.gz` from `https://archive.mariadb.org/mariadb-11.8.7/source/` (114 MB)
- [x] `bosh upload-blobs` records object_id `2ef0552a-…`
- [x] `bosh create-release --force --timestamp-version` builds dev `4.0.0+dev.1779790894`
- [x] Uploaded to internal `ocfp-aws-lab-ocf-us-east-1` director
- [x] Deployed against `emptyvm` on the lab (4:58 compile, clean install)
- [x] Smoke test on the deployed VM:
  ```
  /var/vcap/packages/toolbelt-mysql-client/bin/mariadb --version
  → mariadb from 11.8.7-MariaDB, client 15.2 for Linux (x86_64) using readline 5.1
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)