### PR TITLE
Upgrade wireshark/tshark 4.4.2 -> 4.6.6

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -156,6 +156,7 @@ tshark/pkgconf-2.3.0.tar.xz:
   sha: sha256:3a9080ac51d03615e7c1910a0a2a8df08424892b5f13b0628a204d3fcce0ea8b
 tshark/wireshark-4.6.6.tar.xz:
   size: 56334204
+  object_id: adf43ba4-4cd0-4c68-586b-471ebaaa1ea0
   sha: sha256:27e7ff780cd68a7466082be82ca26c06a002e74a71646ef3a6e4683e444c1a86
 valkey/valkey-9.1.0.tar.gz:
   size: 4375381

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -154,10 +154,9 @@ tshark/pkgconf-2.3.0.tar.xz:
   size: 316160
   object_id: 2bc28dbf-66ce-4716-5caf-79eec1ae4793
   sha: sha256:3a9080ac51d03615e7c1910a0a2a8df08424892b5f13b0628a204d3fcce0ea8b
-tshark/wireshark-4.4.2.tar.xz:
-  size: 46763620
-  object_id: 7001f929-312a-4f61-401e-60da07fd512a
-  sha: sha256:6053d97499c83feb87ce1d7f732d9c889c6c18bb334de67e65dca11483b0514e
+tshark/wireshark-4.6.6.tar.xz:
+  size: 56334204
+  sha: sha256:27e7ff780cd68a7466082be82ca26c06a002e74a71646ef3a6e4683e444c1a86
 valkey/valkey-9.1.0.tar.gz:
   size: 4375381
   object_id: 92730ec1-448f-4be2-7e27-1bf1555d397b

--- a/packages/toolbelt-tshark/DEPENDENCIES.md
+++ b/packages/toolbelt-tshark/DEPENDENCIES.md
@@ -4,13 +4,13 @@ This file documents the dependency relationships and version choices for
 each tshark build. The packaging script builds these in order; the spec
 file lists the corresponding blobs.
 
-## Wireshark 4.4.2 (current)
+## Wireshark 4.6.6 (current)
 
 Stemcell: Ubuntu Jammy (22.04)
 - glibc 2.35, glib 2.72 (too old for Wireshark 4.x which requires glib 2.76+)
 
 Note: Ubuntu Noble (24.04) stemcell is planned. Noble ships glib 2.80 and
-glibc 2.39. Wireshark 4.4.2 requires glib 2.76+, so Noble's system glib
+glibc 2.39. Wireshark 4.6.6 requires glib 2.76+, so Noble's system glib
 may be sufficient. When migrating to Noble, evaluate whether glib (and its
 build chain: meson, ninja, pkgconf, libffi, Python) can be dropped from
 this build in favor of the system version.

--- a/packages/toolbelt-tshark/packaging
+++ b/packages/toolbelt-tshark/packaging
@@ -66,7 +66,7 @@ set -x
 #   tshark/libpcap-1.10.5.tar.gz        https://www.tcpdump.org/release/
 #   tshark/libgpg-error-1.58.tar.bz2    https://gnupg.org/ftp/gcrypt/libgpg-error/
 #   tshark/libgcrypt-1.11.2.tar.bz2     https://gnupg.org/ftp/gcrypt/libgcrypt/
-#   tshark/wireshark-4.4.2.tar.xz       https://www.wireshark.org/download/src/all-versions/
+#   tshark/wireshark-4.6.6.tar.xz       https://www.wireshark.org/download/src/all-versions/
 #   python/Python-3.14.2.tgz            https://www.python.org/downloads/source/
 #
 # ============================================================================
@@ -195,7 +195,7 @@ tar -xjf tshark/libgcrypt-1.11.2.tar.bz2
  make install) || exit 1
 
 # ============================================================================
-# Build Wireshark 4.4.2 (tshark CLI only)
+# Build Wireshark 4.6.6 (tshark CLI only)
 # ============================================================================
 # cmake flags:
 #   BUILD_wireshark=OFF  - skip GUI (requires Qt)
@@ -215,9 +215,9 @@ tar -xjf tshark/libgcrypt-1.11.2.tar.bz2
 # If needed later, use the release tarball from
 # https://ftp.osuosl.org/pub/xiph/releases/speex/ which includes a
 # pre-generated configure script.
-# https://www.wireshark.org/download/src/all-versions/wireshark-4.4.2.tar.xz
-tar -xJf tshark/wireshark-4.4.2.tar.xz
-(cd wireshark-4.4.2
+# https://www.wireshark.org/download/src/all-versions/wireshark-4.6.6.tar.xz
+tar -xJf tshark/wireshark-4.6.6.tar.xz
+(cd wireshark-4.6.6
  if command -v cmake >/dev/null 2>&1; then
    export C_INCLUDE_PATH="${BOSH_INSTALL_TARGET}/include"
    mkdir -p build && cd build

--- a/packages/toolbelt-tshark/spec
+++ b/packages/toolbelt-tshark/spec
@@ -12,4 +12,4 @@ files:
   - tshark/libpcap-1.10.5.tar.gz
   - tshark/libgpg-error-1.58.tar.bz2
   - tshark/libgcrypt-1.11.2.tar.bz2
-  - tshark/wireshark-4.4.2.tar.xz
+  - tshark/wireshark-4.6.6.tar.xz


### PR DESCRIPTION
## Summary
- Upgrade wireshark/tshark from 4.4.2 to 4.6.6
- Update blob object_id in config/blobs.yml for the new wireshark 4.6.6 tarball

## Test plan
- [ ] `bosh create-release` succeeds
- [ ] `tshark --version` reports 4.6.6 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)