### PR TITLE
Fix stale spruce version comment (v1.35.11)

### DIFF
--- a/packages/toolbelt-spruce/packaging
+++ b/packages/toolbelt-spruce/packaging
@@ -2,7 +2,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # link: https://github.com/geofffranks/spruce/releases
-# spruce version:	v1.35.5
+# spruce version:	v1.35.11
 
 
 # Detect # of CPUs so make jobs can be parallelized


### PR DESCRIPTION
The version comment in `packages/toolbelt-spruce/packaging` still read `v1.35.5`, but the spruce blob was bumped to v1.35.10 and then v1.35.11 before the v4.0.1 release. Update the comment to match the blob that actually ships (v1.35.11).

Comment-only change — no packaging logic touched.